### PR TITLE
Item slot validation changes & item purchase logic

### DIFF
--- a/bots/MyUtility.lua
+++ b/bots/MyUtility.lua
@@ -484,6 +484,16 @@ function U.IsTeleporting(bot)
   return bot:HasModifier("modifier_teleporting")
 end
 
+function U.IsItemUsable(bot, item)
+  -- Only TP scroll can be in slot 15, but 15 is not considered a 'main' slot type, so we check for
+  -- that specially.
+  return item ~= nil and (bot:GetItemSlotType(item.slot) == ITEM_SLOT_TYPE_MAIN or item.slot == 15)
+end
+
+function U.IsItemInBackpack(bot, item)
+  return item ~= nil and  bot:GetItemSlotType(item.slot) == ITEM_SLOT_TYPE_BACKPACK
+end
+
 function U.enum(entries)
   local objects = {}
   for id, name in pairs(entries) do

--- a/bots/MyUtility.lua
+++ b/bots/MyUtility.lua
@@ -439,12 +439,17 @@ function U.GetWeakestUnit(units)
 end
 
 local function GetItem(bot, item_name)
-   local itemSlot = bot:FindItemSlot(item_name)
-   if itemSlot == -1 then
-      return nil
-   else
-      return bot:GetItemInSlot(itemSlot)
-   end
+  local itemSlot = bot:FindItemSlot(item_name)
+  local item = nil
+
+  if itemSlot ~= -1 then
+    item = bot:GetItemInSlot(itemSlot)
+  end
+
+  return {
+    slot = itemSlot,
+    item = item
+  }
 end
 
 function U.GetItemWard(bot)

--- a/bots/bot_nevermore.lua
+++ b/bots/bot_nevermore.lua
@@ -1121,23 +1121,6 @@ local function AbilityUsageThink(botLevel, botAttackDamage, enemyHero, enemyCree
 end
 
 ----------------------------------------------------------------------------------------------------
--- Function called every frame to determine what items to buy
-----------------------------------------------------------------------------------------------------
-local function ItemPurchaseThink(botManaPercentage, botHealthPercentage)
-  if bot:DistanceFromFountain() <= 5 and mutils.GetItemTPScroll(bot) == nil then
-    table.insert(itemToBuy, 1, "item_tpscroll")
-  end
-
-	if itemsToBuy[1] ~= "item_flask" and (botHealthPercentage <= 0.6) then
-		table.insert(itemsToBuy, 1, "item_flask")
-	end
-
-	if itemsToBuy[1] ~= "item_enchanted_mango" and (botManaPercentage <= 0.6) then
-		table.insert(itemsToBuy, 1, "item_enchanted_mango")
-	end
-end
-
-----------------------------------------------------------------------------------------------------
 -- Function called every frame to determine if and what item(s) to use
 ----------------------------------------------------------------------------------------------------
 local function ItemUsageThink(botManaLevel, botManaPercentage, botHealthLevel, botHealthPercentage)

--- a/bots/bot_nevermore.lua
+++ b/bots/bot_nevermore.lua
@@ -1159,13 +1159,10 @@ local function ItemUsageThink(botManaLevel, botManaPercentage, botHealthLevel, b
   -- The assumption here is that this method will be called only after game starts
   -- (i.e., creeps started)
   local tpScroll = mutils.GetItemTPScroll(bot)
-  if bot:DistanceFromFountain() <= 5 and tpScroll ~= nil then
-    -- Special 'valid' item check for item_tpscroll
-    if tpScroll.slot == 15 then
-      print("using tp_scroll from "..tostring(bot:DistanceFromFountain()).." on location: "..tostring(mutils.GetT1Location()))
-      bot:Action_UseAbilityOnLocation(tpScroll.item, mutils.GetT1Location())
-      return botState.STATE_TELEPORTING
-    end
+  if bot:DistanceFromFountain() <= 5 and mutils.IsItemUsable(bot, tpScroll) then
+    print("using tp_scroll from "..tostring(bot:DistanceFromFountain()).." on location: "..tostring(mutils.GetT1Location()))
+    bot:Action_UseAbilityOnLocation(tpScroll.item, mutils.GetT1Location())
+    return botState.STATE_TELEPORTING
   end
 
   return botState.STATE_IDLE

--- a/bots/item_purchase_nevermore.lua
+++ b/bots/item_purchase_nevermore.lua
@@ -1,19 +1,45 @@
+local mutils = require(GetScriptDirectory() ..  "/MyUtility")
+
 X = {}
-X["tableItemsToBuy"] = { 
-				"item_ward_observer","item_faerie_fire","item_quelling_blade",
-				"item_slippers", "item_flask", "item_slippers",
-				"item_magic_stick","item_branches","item_branches","item_recipe_magic_wand","item_circlet","item_recipe_wraith_band",
-				"item_boots","item_gloves","item_boots_of_elves",
-				"item_blade_of_alacrity","item_boots_of_elves","item_recipe_yasha"
+X["tableItemsToBuy"] = {
+  "item_ward_observer","item_faerie_fire","item_quelling_blade",
+  "item_slippers", "item_flask", "item_slippers",
+  "item_magic_stick","item_branches","item_branches","item_recipe_magic_wand","item_circlet","item_recipe_wraith_band",
+  "item_boots","item_gloves","item_boots_of_elves",
+  "item_blade_of_alacrity","item_boots_of_elves","item_recipe_yasha"
 };
 
 
 ----------------------------------------------------------------------------------------------------
 local npcBot = GetBot()
+
+function GetBotHealthyStats()
+  botManaLevel = npcBot:GetMana()
+	botManaPercentage = botManaLevel/npcBot:GetMaxMana()
+	botHealthLevel = npcBot:GetHealth()
+  botHealthPercentage = botHealthLevel/npcBot:GetMaxHealth()
+  return botManaPercentage, botHealthPercentage
+end
+
 function ItemPurchaseThink()
-	
+  botManaPercentage, botHealthPercentage = GetBotHealthyStats()
+
+  if npcBot:DistanceFromFountain() <= 5 and mutils.GetItemTPScroll(npcBot) == nil
+     and X["tableItemsToBuy"][1] ~= "item_tpscroll" then
+    table.insert(X["tableItemsToBuy"], 1, "item_tpscroll")
+  end
+
+	if X["tableItemsToBuy"][1] ~= "item_flask" and (botHealthPercentage <= 0.6) then
+		table.insert(X["tableItemsToBuy"], 1, "item_flask")
+	end
+
+	if X["tableItemsToBuy"][1] ~= "item_enchanted_mango" and (botManaPercentage <= 0.6) then
+		table.insert(X["tableItemsToBuy"], 1, "item_enchanted_mango")
+	end
+
 	if ( #X["tableItemsToBuy"] == 0 )
 	then
+    print("nothing to buy")
 		npcBot:SetNextItemPurchaseValue( 0 );
 		return;
 	end
@@ -24,6 +50,7 @@ function ItemPurchaseThink()
 
 	if ( npcBot:GetGold() >= GetItemCost( sNextItem ) )
 	then
+    print("purchasing item: "..sNextItem)
 		npcBot:ActionImmediate_PurchaseItem( sNextItem );
 		table.remove( X["tableItemsToBuy"], 1 );
 	end


### PR DESCRIPTION
imo `GetItem` should do what its called - just get the item if its available. The responsibility of validating whether its in a usable slot should fall on the callers (added some helper methods to do that easily).

Also moved the logic inside `ItemPurchaseThink` to the `item_purchase_nervermore` script because we were just modifying a copy of the item purchase table from the main script.